### PR TITLE
repeated_timer: finish condition variable should release mutex when waiting for still running task finished.

### DIFF
--- a/src/braft/configuration_manager.cpp
+++ b/src/braft/configuration_manager.cpp
@@ -63,7 +63,11 @@ void ConfigurationManager::set_snapshot(ConfigurationEntry&& entry) {
 
 void ConfigurationManager::get(int64_t last_included_index,
                                ConfigurationEntry* conf) {
-    if (_configurations.empty()) {
+    if (_configurations.empty() ||
+        _configurations.begin()->id.index > last_included_index) {
+        // configurations is empty or
+        // the smallest index configuration entry is greater than
+        // last_included_index.
         CHECK_GE(last_included_index, _snapshot.id.index);
         *conf = _snapshot;
         return;
@@ -80,8 +84,9 @@ void ConfigurationManager::get(int64_t last_included_index,
             return rhs.id.index > index;
         });
 
-    CHECK(it != _configurations.rend());
+    CHECK(it != _configurations.rend());  // must found.
     *conf = *it;
+    return;
 }
 
 const ConfigurationEntry& ConfigurationManager::last_configuration() const {

--- a/src/braft/configuration_manager.h
+++ b/src/braft/configuration_manager.h
@@ -73,6 +73,8 @@ class ConfigurationManager {
 
     void set_snapshot(ConfigurationEntry&& snapshot);
 
+    // find the latest ConfigurationEntry which `last_included_index`
+    // log belongs to.
     void get(int64_t last_included_index, ConfigurationEntry* entry);
 
     const ConfigurationEntry& last_configuration() const;

--- a/src/braft/repeated_timer_task.h
+++ b/src/braft/repeated_timer_task.h
@@ -15,13 +15,13 @@
 // Authors: Zhangyi Chen(chenzhangyi01@baidu.com)
 //          Ma,Jingwei(majingwei@baidu.com)
 
-#ifndef BRAFT_REPEATED_TIMER_TASK_H
-#define BRAFT_REPEATED_TIMER_TASK_H
+#pragma once
 
 #include <bthread/unstable.h>
 
 #include "braft/macros.h"
 #include "bthread/countdown_event.h"
+#include "butil/synchronization/condition_variable.h"
 
 namespace braft {
 
@@ -79,9 +79,7 @@ class RepeatedTimerTask {
     bool _running;
     bool _destroyed;
     bool _invoking;
-    bthread::CountdownEvent _finish_event;
+    butil::ConditionVariable _finish_cv;
 };
 
 }  //  namespace braft
-
-#endif  // BRAFT_REPEATED_TIMER_TASK_H


### PR DESCRIPTION
related failed ci: https://github.com/ehds/mbraft/actions/runs/9445927788/job/26014514206.

1. repeated_timer `finish_cv` should release `mutex` when waiting for singal.
2. Waiting for task only when `bthread_timer_del` return 1 (still running), or task never to be excuted, we would block here forever. 

related failed ci: https://github.com/ehds/mbraft/actions/runs/9461268281/job/26061655501?pr=14
3. return snapshot entry index when the smallest index configuration entry is greater than
last_included_index.